### PR TITLE
increased time between rounds to 2 min and added 1 min team prep time

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,9 @@ function load_config()
 	global.starting_equipment = "none"
 	global.team_joining = "auto_assign"
 	global.setup_finished = false
+	global.team_preparing_period = false
 	global.time_between_rounds = 120 -- seconds
+	global.prepare_period = 60 -- seconds
 	global.config =
 		{
 			["number_of_teams"] = 2,

--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,7 @@ function load_config()
 	global.starting_equipment = "none"
 	global.team_joining = "auto_assign"
 	global.setup_finished = false
-	global.time_between_rounds = 60 -- seconds
+	global.time_between_rounds = 120 -- seconds
 	global.config =
 		{
 			["number_of_teams"] = 2,

--- a/control.lua
+++ b/control.lua
@@ -350,6 +350,7 @@ function team_prepare()
 				--player.character_build_distance_bonus = -1
 				--player.character_item_drop_distance_bonus = -1
 				--player.character_reach_distance_bonus = -1
+				--player.character_resource_reach_distance_bonus = -1
 				--player.character_item_pickup_distance_bonus = -1
 				--player.character_loot_pickup_distance_bonus = -1
 			end


### PR DESCRIPTION
It seems that after a multi-hour game that a one minute break is too short. I set it to two minutes but it might not be bad to increase it further.

I also added a one minute team preparation period after team selection becomes available. Player who join a team during this period will find that they are frozen in place, unable to move, mine, or craft. This gives teams a little time to strategize before the match starts.

Minor: I also made how check_player_color() checks game.tick consistent with how the other functions work.